### PR TITLE
Tweak the readme to add a bit mode detail.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 
-=========================
-Semantic with our Plugins
-=========================
+==========================
+Semantics with our Plugins
+==========================
 
-Semantic with our plugins is a web application for searching, discovering, and annotating plugins used in OpenCOR, MAP Client, and CTK applications.
+Semantics with our Plugins is the concept of using semantic web technologies to describe our software plugins in order to make them discoverable and reusable. Currently this repository contains a web application for searching, discovering, and annotating plugins used in `MAP Client <https://map-client.readthedocs.io>`_ and our CTK-based applications.
 


### PR DESCRIPTION
Semantics seems better to me, but could be convinced otherwise. Not sure the best link to use for our CTK applications or whether we should simply link to CTK?